### PR TITLE
Fix "view on slack" link

### DIFF
--- a/pages/api/posts.js
+++ b/pages/api/posts.js
@@ -42,7 +42,7 @@ export const transformPost = p => ({
   id: p.id,
   user: p.user ? p.user : {},
   timestamp: p.messageTimestamp || null,
-  slackUrl: `https://hackclub.slack.com/archives/${p.channel}/p1628524815020800`,
+  slackUrl: `https://hackclub.slack.com/archives/${p.channel}/p${p.messageTimestamp.toString().replace('.', '').padEnd(16, '0')}`,
   postedAt: formatTS(p.messageTimestamp),
   text: p.text != null ? p.text : '',
   attachments: p.attachments,


### PR DESCRIPTION
I'm not exactly sure how the `messageTimestamp` is formatted, but hopefully this works?