### PR TITLE
Try fixing cors error for custom domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,6 @@ Our dark mode is powered by [`prefers-color-scheme: dark`](https://developer.moz
 
 To put your profile on your own domain, run `/scrappy setdomain <domain>` in Slack, giving your website’s hostname (e.g. [`zachlatta.com`](https://zachlatta.com)). Then, add a `CNAME` record on your DNS provider, pointed to `cname.vercel-dns.com`. If you’re curious how this works, it’s [open source right here](http://github.com/hackclub/summer-domains).
 
-<small>
-  (Unfortunately, if your DNS is managed by Vercel, you’re not able to use this
-  feature.)
-</small>
-
 ## Website widget
 
 Want to showcase your streak on your personal website? We’ve created a small widget that you can put on your website with 2 lines of code. It shows up in the bottom right corner. Just replace `username` with your Scrappy username. Here’s the code snippet:

--- a/pages/[username]/index.js
+++ b/pages/[username]/index.js
@@ -132,7 +132,9 @@ const Profile = ({
                 </a>
               )}
             </div>
-            {profile.customAudioURL && <AudioPlayer url={profile.customAudioURL} />}
+            {profile.customAudioURL && (
+              <AudioPlayer url={profile.customAudioURL} />
+            )}
           </div>
         </section>
       </div>
@@ -208,7 +210,7 @@ const Profile = ({
 const fetcher = url => fetch(url).then(r => r.json())
 
 const Page = ({ username = '', router = {}, initialData = {} }) => {
-  const { data, error } = useSWR(`/api/users/${username}`, fetcher, {
+  const { data, error } = useSWR(`/api/users/${username}/`, fetcher, {
     initialData,
     refreshInterval: 5000
   })


### PR DESCRIPTION
Scrapbook on a custom domain (for example https://scrapbook.maggieliu.dev/) doesn't work because of a cors error -- I think the problem is that `trailingSlash` is set as true in `next.config.js` so maybe sending the fetch request to the url with a trailing slash will fix it?