### PR TITLE
Add documentation around features

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ Scrappy, our handy dandy [Slack bot](https://github.com/hackclub/scrappy), not o
 - *Remove* a post: delete the Slack message and Scrappy will automatically update for you
 - *Edit* a post: edit the Slack message and it will automatically update for you
 
+## Custom domains
+
+To put your profile on your own domain, run `/scrappy setdomain <domain>` in Slack, giving your website’s hostname (e.g. [`zachlatta.com`](https://zachlatta.com)). Then, add a `CNAME` record on your DNS provider, pointed to `cname.vercel-dns.com`. If you’re curious how this works, it’s [open source right here](http://github.com/hackclub/summer-domains).
+
+_(Unfortunately, if your DNS is managed by Vercel, you’re not able to use this feature.)_
+
 ## CSS customization
 
 To customize the CSS on your profile page, run `/scrappy setcss <link>` in Slack, giving a link to a CSS file or a [GitHub Gist](https://gist.github.com). [Here’s the default CSS](https://scrapbook.hackclub.com/themes/default.css), for your overwriting pleasure.

--- a/README.md
+++ b/README.md
@@ -43,8 +43,6 @@ Scrappy, our handy dandy [Slack bot](https://github.com/hackclub/scrappy), not o
 
 To put your profile on your own domain, run `/scrappy setdomain <domain>` in Slack, giving your website’s hostname (e.g. [`zachlatta.com`](https://zachlatta.com)). Then, add a `CNAME` record on your DNS provider, pointed to `cname.vercel-dns.com`. If you’re curious how this works, it’s [open source right here](http://github.com/hackclub/summer-domains).
 
-_(Unfortunately, if your DNS is managed by Vercel, you’re not able to use this feature.)_
-
 ## CSS customization
 
 To customize the CSS on your profile page, run `/scrappy setcss <link>` in Slack, giving a link to a CSS file or a [GitHub Gist](https://gist.github.com). [Here’s the default CSS](https://scrapbook.hackclub.com/themes/default.css), for your overwriting pleasure.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Behind the scenes, the site runs on [Next.js](https://nextjs.org), React.js, & [
 
 ## How do I join?
 
-Your Scrapbook is automatically generated when you make your first Scrapbook post. In order to post, you'll need to [join the Hack Club Slack](https://hackclub.com/slack). Once you've completed the onboarding flow in Slack and have access to all of the channels, join the `#scrapbook` channel. From here, Scrapbook posts are automatically generated when you post a message in the `#scrapbook` channel.
+Your Scrapbook is automatically generated for you when you make your first Scrapbook post. In order to post, you'll need to [join the Hack Club Slack](https://hackclub.com/slack). Once you've completed the onboarding flow in Slack and have access to all of the channels, join the `#scrapbook` channel. From here, Scrapbook posts are automatically generated for you when you post a message in the `#scrapbook` channel.
 
 A post requires just two things: a description and an image. Your image can be dragged straight into Slack and Scrapbook will take care of the rest. [An example message](https://hackclub.slack.com/archives/C01504DCLVD/p1646030307450419) into Slack might look like:
 
@@ -25,7 +25,7 @@ _Example pulled from [audreyolafz's scrapbook](https://scrapbook.hackclub.com/au
 
 ## Scrappy, the Slack Bot
 
-Scrappy, our handy dandy [Slack bot](https://github.com/hackclub/scrappy), handles not only the automatic generation of things, but provides some features as well! These features are also documented if you send the message `/scrappy` in Slack.
+Scrappy, our handy dandy [Slack bot](https://github.com/hackclub/scrappy), not only handles the automatic generation of things, but provides some helpful commands as well. These commands are also documented in our Slack if you send the message `/scrappy` in any channel.
 
 - `/scrappy-togglestreaks`: toggles your streak count on/off in your status
 - `/scrappy-togglestreaks all`: opts out of streaks completely

--- a/README.md
+++ b/README.md
@@ -4,15 +4,40 @@
 
 We at Hack Club HQ made this because the times of our lives when we’ve really improved our skills came from **showing up every day**. Even if we didn’t make something amazing every day, the consistency was key. Scrapbook is a tool to help us all do that with ease.
 
-This repo is the website for [Hack Club](https://hackclub.com/)’s [Scrapbook](https://scrapbook.hackclub.com/), which was originally built for the [2020 Summer of Making](https://summer.hackclub.com/) but it is now a permanent feature of the community.
-
-## How do I join?
-
-[Join the Hack Club Slack](https://hackclub.com/slack) to participate, then join the `#scrapbook` channel.
+This repo is the website for [Hack Club](https://hackclub.com/)’s [Scrapbook](https://scrapbook.hackclub.com/), which was originally built for the [2020 Summer of Making](https://summer.hackclub.com/), but is now a permanent feature of the community.
 
 ## How does it work?
 
 Behind the scenes, the site runs on [Next.js](https://nextjs.org), React.js, & [SWR](https://swr.now.sh) for data fetching. All pages are [static-rendered](https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation), hosted on [Vercel](https://vercel.com). Videos are hosted by [Mux](https://mux.com). The custom domains use a [Vercel serverless function](https://github.com/hackclub/summer-domains). The [Slack integration](https://github.com/hackclub/scrappy) runs on [Express.js](https://expressjs.com), hosted on [Heroku](https://heroku.com). All the data is stored in a [PostgreSQL](https://www.postgresql.org) database, fetched using [Prisma](https://prisma.io). We built it in a week whilst preparing for the [2020 Summer of Making](https://summer.hackclub.com/).
+
+## How do I join?
+
+Your Scrapbook is automatically generated when you make your first Scrapbook post. In order to post, you'll need to [join the Hack Club Slack](https://hackclub.com/slack). Once you've completed the onboarding flow in Slack and have access to all of the channels, join the `#scrapbook` channel. From here, Scrapbook posts are automatically generated when you post a message in the `#scrapbook` channel.
+
+A post requires just two things: a description and an image. Your image can be dragged straight into Slack and Scrapbook will take care of the rest. [An example message](https://hackclub.slack.com/archives/C01504DCLVD/p1646030307450419) into Slack might look like:
+
+```
+learned Express generator today - now back to a ton of (organized) files
+
+![Example Scrapbook post image](https://cloud-f8by3gcpv-hack-club-bot.vercel.app/0screenshot_2022-02-27_223754.png)
+```
+_Example pulled from [audreyolafz's scrapbook](https://scrapbook.hackclub.com/audreyolafz)_
+
+## Scrappy, the Slack Bot
+
+Scrappy, our handy dandy [Slack bot](https://github.com/hackclub/scrappy), handles not only the automatic generation of things, but provides some features as well! These features are also documented if you send the message `/scrappy` in Slack.
+
+- `/scrappy-togglestreaks`: toggles your streak count on/off in your status
+- `/scrappy-togglestreaks all`: opts out of streaks completely
+- `/scrappy-open`: opens your scrapbook (or another user's if you specify a username)
+- `/scrappy-setcss`: adds a custom CSS file to your scrapbook profile. Check out this cool example!
+- `/scrappy-setdomain`: links a custom domain to your scrapbook profile, e.g. [https://zachlatta.com](https://zachlatta.com)
+- `/scrappy-setusername`: change your profile username
+- `/scrappy-setaudio`: links an audio file to your Scrapbook. [See an example here](https://scrapbook.hackclub.com/matthew)!
+- `/scrappy-setwebhook`: create a Scrappy Webhook we will make a blank fetch request to this URL every time you post
+- `/scrappy-webring`: adds or removes someone to your webring
+- *Remove* a post: delete the Slack message and Scrappy will automatically update for you
+- *Edit* a post: edit the Slack message and it will automatically update for you
 
 ## CSS customization
 
@@ -62,10 +87,6 @@ Some “relative” colors use these colors for various components:
 
 Our dark mode is powered by [`prefers-color-scheme: dark`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme).
 
-## Custom domains
-
-To put your profile on your own domain, run `/scrappy setdomain <domain>` in Slack, giving your website’s hostname (e.g. [`zachlatta.com`](https://zachlatta.com)). Then, add a `CNAME` record on your DNS provider, pointed to `cname.vercel-dns.com`. If you’re curious how this works, it’s [open source right here](http://github.com/hackclub/summer-domains).
-
 ## Website widget
 
 Want to showcase your streak on your personal website? We’ve created a small widget that you can put on your website with 2 lines of code. It shows up in the bottom right corner. Just replace `username` with your Scrappy username. Here’s the code snippet:
@@ -80,6 +101,23 @@ If you have a custom domain, you can optionally link the scrapbook widget to it!
 ```js
 <script src="https://summer.hackclub.com/scrapbookwidget.js"></script>
 <script>displayScrapbookUsername('username', 'https://scrapbook.example.com')</script>
+```
+
+## RSS feed
+
+Want to get an RSS feed of your Scrapbook posts? Just append `.rss` to the end of your Scrapbook profile's URL, like so: https://scrapbook.hackclub.com/(username).rss
+
+## macOS app
+
+Hack Clubbers using a Mac can post directly from their menu bar using Scrapple, an app built by [@LinusS1](https://github.com/LinusS1)! From the menu bar, type in the update, select the attachments for the post and send it off into the interweb…
+
+You can [download the app here](https://github.com/LinusS1/Scrapple/releases), and it’s [open source here](https://github.com/LinusS1/Scrapple).
+
+To install using Homebrew Cask:
+
+```
+brew tap LinusS1/homebrew-tap
+brew cask install scrapple
 ```
 
 ## Public API

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ A post requires just two things: a description and an image. Your image can be d
 
 ```
 learned Express generator today - now back to a ton of (organized) files
-
-![Example Scrapbook post image](https://cloud-f8by3gcpv-hack-club-bot.vercel.app/0screenshot_2022-02-27_223754.png)
 ```
+![Example Scrapbook post image](https://cloud-f8by3gcpv-hack-club-bot.vercel.app/0screenshot_2022-02-27_223754.png)
+
 _Example pulled from [audreyolafz's scrapbook](https://scrapbook.hackclub.com/audreyolafz)_
 
 ## Scrappy, the Slack Bot

--- a/pages/about.mdx
+++ b/pages/about.mdx
@@ -55,8 +55,6 @@ Scrappy, our handy dandy [Slack bot](https://github.com/hackclub/scrappy), not o
 
 To put your profile on your own domain, run `/scrappy setdomain <domain>` in Slack, giving your website’s hostname (e.g. [`zachlatta.com`](https://zachlatta.com)). Then, add a `CNAME` record on your DNS provider, pointed to `cname.vercel-dns.com`. If you’re curious how this works, it’s [open source right here](http://github.com/hackclub/summer-domains).
 
-<small>(Unfortunately, if your DNS is managed by Vercel, you’re not able to use this feature.)</small>
-
 ## CSS customization
 
 To customize the CSS on your profile page, run `/scrappy-setcss <link>` in Slack, giving a link to a CSS file or a [GitHub Gist](https://gist.github.com). [Here’s the default CSS](https://scrapbook.hackclub.com/themes/default.css), for your overwriting pleasure.

--- a/pages/about.mdx
+++ b/pages/about.mdx
@@ -51,6 +51,12 @@ Scrappy, our handy dandy [Slack bot](https://github.com/hackclub/scrappy), not o
 - *Remove* a post: delete the Slack message and Scrappy will automatically update for you
 - *Edit* a post: edit the Slack message and it will automatically update for you
 
+## Custom domains
+
+To put your profile on your own domain, run `/scrappy setdomain <domain>` in Slack, giving your website’s hostname (e.g. [`zachlatta.com`](https://zachlatta.com)). Then, add a `CNAME` record on your DNS provider, pointed to `cname.vercel-dns.com`. If you’re curious how this works, it’s [open source right here](http://github.com/hackclub/summer-domains).
+
+<small>(Unfortunately, if your DNS is managed by Vercel, you’re not able to use this feature.)</small>
+
 ## CSS customization
 
 To customize the CSS on your profile page, run `/scrappy-setcss <link>` in Slack, giving a link to a CSS file or a [GitHub Gist](https://gist.github.com). [Here’s the default CSS](https://scrapbook.hackclub.com/themes/default.css), for your overwriting pleasure.

--- a/pages/about.mdx
+++ b/pages/about.mdx
@@ -24,7 +24,7 @@ Behind the scenes, the site runs on [Next.js](https://nextjs.org), React.js, & [
 
 ## How do I join?
 
-Your Scrapbook is automatically generated when you make your first Scrapbook post. In order to post, you'll need to [join the Hack Club Slack](https://hackclub.com/slack). Once you've completed the onboarding flow in Slack and have access to all of the channels, join the `#scrapbook` channel. From here, Scrapbook posts are automatically generated when you post a message in the `#scrapbook` channel.
+Your Scrapbook is automatically generated for you when you make your first Scrapbook post. In order to post, you'll need to [join the Hack Club Slack](https://hackclub.com/slack). Once you've completed the onboarding flow in Slack and have access to all of the channels, join the `#scrapbook` channel. From here, Scrapbook posts are automatically generated for you when you post a message in the `#scrapbook` channel.
 
 A post requires just two things: a description and an image. Your image can be dragged straight into Slack and Scrapbook will take care of the rest. [An example message](https://hackclub.slack.com/archives/C01504DCLVD/p1646030307450419) into Slack might look like:
 
@@ -37,7 +37,7 @@ _Example pulled from [audreyolafz's scrapbook](https://scrapbook.hackclub.com/au
 
 ## Scrappy, the Slack Bot
 
-Scrappy, our handy dandy [Slack bot](https://github.com/hackclub/scrappy), handles not only the automatic generation of things, but provides some features as well! These features are also documented if you send the message `/scrappy` in Slack.
+Scrappy, our handy dandy [Slack bot](https://github.com/hackclub/scrappy), not only handles the automatic generation of things, but provides some helpful commands as well. These commands are also documented in our Slack if you send the message `/scrappy` in any channel.
 
 - `/scrappy-togglestreaks`: toggles your streak count on/off in your status
 - `/scrappy-togglestreaks all`: opts out of streaks completely

--- a/pages/about.mdx
+++ b/pages/about.mdx
@@ -18,13 +18,38 @@ Originally built for the [Summer of Making](https://summer.hackclub.com/), use S
 
 We at Hack Club HQ made this because the times of our lives when we’ve really improved our skills came from **showing up every day**. Even if we didn’t make something amazing every day, the consistency was key. Scrapbook is a tool to help us all do that with ease.
 
-## How do I join?
-
-[Join the Hack Club Slack](https://hackclub.com/slack) to participate, then join the `#scrapbook` channel.
-
 ## How does it work?
 
-Behind the scenes, the site ([all open source!](https://github.com/hackclub/summer-scrapbook)) runs on [Next.js](https://nextjs.org), React.js, & [SWR](https://swr.now.sh) for data fetching. All pages are [static-rendered](https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation), hosted on [Vercel](https://vercel.com). Videos are hosted by [Mux](https://mux.com). The custom domains use a [Vercel serverless function](https://github.com/hackclub/summer-domains). The [Slack integration](https://github.com/hackclub/scrappy) runs on [Express.js](https://expressjs.com), hosted on [Heroku](https://heroku.com). All the data is stored in a [PostgreSQL](https://www.postgresql.org) database, fetched using [Prisma](https://prisma.io). We built it in a week.
+Behind the scenes, the site runs on [Next.js](https://nextjs.org), React.js, & [SWR](https://swr.now.sh) for data fetching. All pages are [static-rendered](https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation), hosted on [Vercel](https://vercel.com). Videos are hosted by [Mux](https://mux.com). The custom domains use a [Vercel serverless function](https://github.com/hackclub/summer-domains). The [Slack integration](https://github.com/hackclub/scrappy) runs on [Express.js](https://expressjs.com), hosted on [Heroku](https://heroku.com). All the data is stored in a [PostgreSQL](https://www.postgresql.org) database, fetched using [Prisma](https://prisma.io). We built it in a week whilst preparing for the [2020 Summer of Making](https://summer.hackclub.com/).
+
+## How do I join?
+
+Your Scrapbook is automatically generated when you make your first Scrapbook post. In order to post, you'll need to [join the Hack Club Slack](https://hackclub.com/slack). Once you've completed the onboarding flow in Slack and have access to all of the channels, join the `#scrapbook` channel. From here, Scrapbook posts are automatically generated when you post a message in the `#scrapbook` channel.
+
+A post requires just two things: a description and an image. Your image can be dragged straight into Slack and Scrapbook will take care of the rest. [An example message](https://hackclub.slack.com/archives/C01504DCLVD/p1646030307450419) into Slack might look like:
+
+```
+learned Express generator today - now back to a ton of (organized) files
+```
+<img src="https://cloud-f8by3gcpv-hack-club-bot.vercel.app/0screenshot_2022-02-27_223754.png" />
+
+_Example pulled from [audreyolafz's scrapbook](https://scrapbook.hackclub.com/audreyolafz)_
+
+## Scrappy, the Slack Bot
+
+Scrappy, our handy dandy [Slack bot](https://github.com/hackclub/scrappy), handles not only the automatic generation of things, but provides some features as well! These features are also documented if you send the message `/scrappy` in Slack.
+
+- `/scrappy-togglestreaks`: toggles your streak count on/off in your status
+- `/scrappy-togglestreaks all`: opts out of streaks completely
+- `/scrappy-open`: opens your scrapbook (or another user's if you specify a username)
+- `/scrappy-setcss`: adds a custom CSS file to your scrapbook profile. Check out this cool example!
+- `/scrappy-setdomain`: links a custom domain to your scrapbook profile, e.g. [https://zachlatta.com](https://zachlatta.com)
+- `/scrappy-setusername`: change your profile username
+- `/scrappy-setaudio`: links an audio file to your Scrapbook. [See an example here](https://scrapbook.hackclub.com/matthew)!
+- `/scrappy-setwebhook`: create a Scrappy Webhook we will make a blank fetch request to this URL every time you post
+- `/scrappy-webring`: adds or removes someone to your webring
+- *Remove* a post: delete the Slack message and Scrappy will automatically update for you
+- *Edit* a post: edit the Slack message and it will automatically update for you
 
 ## CSS customization
 
@@ -37,7 +62,7 @@ Want to preview your CSS before adding it to your profile? Check out <Mention us
 If you’d like to change the page-wide fonts or colors, you can change yours with [CSS Custom Properties](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_variables). Here’s the values the site uses by default:
 
 <details>
-  
+
   <summary>Default values</summary>
 
 ```css
@@ -78,17 +103,6 @@ Some “relative” colors use these colors for various components:
 </details>
 
 Our dark mode is powered by [`prefers-color-scheme: dark`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme).
-
-## Custom domains
-
-To put your profile on your own domain, run `/scrappy-setdomain <domain>` in Slack, giving your website’s hostname (e.g. [`zachlatta.com`](https://zachlatta.com)). Then, add a `CNAME` record on your DNS provider, pointed to `cname.vercel-dns.com`. If you’re curious how this works, it’s [open source right here](http://github.com/hackclub/summer-domains).
-
-_Sadly, we have ran out of space and can't register any more domains._
-
-<small>
-  (Unfortunately, if your DNS is managed by Vercel, you’re not able to use this
-  feature.)
-</small>
 
 ## Website widget
 
@@ -213,5 +227,9 @@ This site exposes a public JSON API powered by [Next.js API routes](https://next
   code {
     padding: 0 0.25em;
     border-radius: 0.125em;
+  }
+
+  pre code {
+    padding: 0;
   }
 `}</style>


### PR DESCRIPTION
Add documentation around how to create a scrapbook, how to post, and the slash commands available. Update both README and the `/about` page.