### PR TITLE
Fix avatar/mention styles

### DIFF
--- a/public/themes/default.css
+++ b/public/themes/default.css
@@ -230,11 +230,6 @@
   align-self: center;
 }
 
-/* .mention-avatar {
-  border-radius: 50%;
-  overflow: hidden;
-} */
-
 .header-webring-mention svg {
   color: var(--colors-muted);
   position: absolute;

--- a/public/themes/default.css
+++ b/public/themes/default.css
@@ -83,7 +83,7 @@
     margin-top: 24px;
   }
   .post {
-    width: calc(100vw - 32px)!important;
+    width: calc(100vw - 32px) !important;
   }
 }
 
@@ -175,17 +175,18 @@
   align-items: baseline;
   text-decoration: none;
 }
-.mention div:first-child {
+.mention span:first-child {
   border-radius: 50%;
   overflow: hidden;
   margin-right: 4px;
 }
 
-.post-text-mention div:first-child {
+.post-text-mention span:first-child {
   width: 24px;
   height: 24px;
-  margin-right: 4px!important;
   align-self: flex-end;
+  margin-bottom: 2px !important;
+  margin-right: 2px !important;
 }
 
 .headline,
@@ -228,6 +229,12 @@
   margin: 0 0 6px;
   align-self: center;
 }
+
+/* .mention-avatar {
+  border-radius: 50%;
+  overflow: hidden;
+} */
+
 .header-webring-mention svg {
   color: var(--colors-muted);
   position: absolute;
@@ -276,7 +283,7 @@
   height: 48px;
   border-radius: 24px;
 }
-div + .post-header-container {
+.post-header-container {
   padding-left: 8px;
 }
 .post-header-name {


### PR DESCRIPTION
This PR:

<table>
<tr>
	<td>Avatar mention (rounded avatar)</td>
	<td>Header (added some spacing between the avatar and the name/date)</td>
</tr>
<tr>
	<td><img width="504" alt="Screen Shot 2022-03-07 at 16 20 49" src="https://user-images.githubusercontent.com/72365100/157140830-8c658dd7-f2b7-4f5a-bcb7-9de4351a00ca.png"></td>
	<td><img width="1222" alt="Screen Shot 2022-03-07 at 16 14 55" src="https://user-images.githubusercontent.com/72365100/157140838-ba22d027-4888-4a11-bdc3-e83a2c9f3074.png"></td>
</tr>
</table>




<details>
<summary>Previously:</summary>

<table>
<tr>
	<td><img width="504" alt="Screen Shot 2022-03-07 at 16 23 48" src="https://user-images.githubusercontent.com/72365100/157140994-6a44aeac-d32f-43b6-8241-fe202a7b488c.png"></td>
	<td><img width="1178" alt="Screen Shot 2022-03-07 at 16 22 54" src="https://user-images.githubusercontent.com/72365100/157140964-9428e1da-c6be-4c41-af9b-d8b1a6608842.png"></td>
</tr>
</table>


</details>

