### PR TITLE
Edit grammar in opening /about paragraph

### DIFF
--- a/pages/about.mdx
+++ b/pages/about.mdx
@@ -14,9 +14,9 @@ import Mention from '../components/mention'
 
 # About Scrapbook
 
-Scrapbook helps you **share the things you're working on every day!** As a [Hack Clubber](https://hackclub.com/), you are always learning and building things. Scrapbook allows you to share updates on the things you're doing with the rest of the Hack Club community, and keeps you motivated by recording each day you contribute, tallying that up onto a streak shown on your profile.
+As a [Hack Clubber](https://hackclub.com/), you are always learning and building things. Scrapbook was made by the Hack Club community because many of us have found that **showing up every day** has been key to our success in learning. Even if we didn’t make something big or impressive, showing up consistently and making _something_ was key.
 
-Scrapbook was made by the Hack Club community because many of us have found that **showing up every day** has been key to our success in learning. Even if we didn’t make something big or impressive, showing up consistently and making _something_ was key.
+Scrapbook helps you **share those things you're working on** with the rest of the Hack Club community, and keeps you motivated by recording each day you contribute, tallying up your contribution streak to show on your profile.
 
 ## How do I join?
 


### PR DESCRIPTION
Intro paragraph was a bit repetitive.

Before:
<img width="678" alt="Screen Shot 2022-03-25 at 12 52 04 PM" src="https://user-images.githubusercontent.com/621904/160165751-ec30a402-0e40-4f63-8546-046fe4e296f7.png">

Now:
<img width="660" alt="Screen Shot 2022-03-25 at 12 51 20 PM" src="https://user-images.githubusercontent.com/621904/160165669-d7d96904-dea2-401c-a1cf-9ef66307c3cd.png">