### PR TITLE
Don't include users with zero posts in `/api/users`

### DIFF
--- a/pages/api/users/index.js
+++ b/pages/api/users/index.js
@@ -1,9 +1,7 @@
 import prisma from '../../../lib/prisma'
 
 export const getRawUsers = (onlyFull = false, where = undefined) =>
-  prisma.accounts.findMany({
-    where: null
-  })
+  prisma.accounts.findMany({where})
 
 // Find users with at least one Scrapbook post
 export default async (req, res) => getRawUsers(

--- a/pages/api/users/index.js
+++ b/pages/api/users/index.js
@@ -1,15 +1,18 @@
 import prisma from '../../../lib/prisma'
 
-// Find users with at least one Scrapbook post
-export const getRawUsers = () =>
+export const getRawUsers = (onlyFull = false, where = null) =>
   prisma.accounts.findMany({
-    where: {
-      NOT: {
-        updates: {
-          none: {}
-        }
-      }
-    }
+    where: null
   })
 
-export default async (req, res) => getRawUsers().then(u => res.json(u || []))
+// Find users with at least one Scrapbook post
+export default async (req, res) => getRawUsers(
+  false, 
+  {
+    NOT: {
+      updates: {
+        none: {}
+      }
+    }
+  }
+).then(u => res.json(u || []))

--- a/pages/api/users/index.js
+++ b/pages/api/users/index.js
@@ -1,6 +1,15 @@
 import prisma from '../../../lib/prisma'
 
-export const getRawUsers = (onlyFull = false) =>
-  prisma.accounts.findMany(onlyFull ? { where: { fullSlackMember: true } } : {})
+// Find users with at least one Scrapbook post
+export const getRawUsers = () =>
+  prisma.accounts.findMany({
+    where: {
+      NOT: {
+        updates: {
+          none: {}
+        }
+      }
+    }
+  })
 
 export default async (req, res) => getRawUsers().then(u => res.json(u || []))

--- a/pages/api/users/index.js
+++ b/pages/api/users/index.js
@@ -1,6 +1,6 @@
 import prisma from '../../../lib/prisma'
 
-export const getRawUsers = (onlyFull = false, where = null) =>
+export const getRawUsers = (onlyFull = false, where = undefined) =>
   prisma.accounts.findMany({
     where: null
   })


### PR DESCRIPTION
Not sure if this will break anything, but this PR updates the /api/users route to only return users with at least 1 scrapbook post. Previously, it returned all (full) members of the Slack.


Response is under Vercel's limit of 4MB:
<img width="349" alt="Screen Shot 2022-04-30 at 21 29 23" src="https://user-images.githubusercontent.com/72365100/166132312-5420b50a-d589-4324-ba78-d6b3cd02eccf.png">

Maybe fixes #309
