### PR TITLE
Add letter spacing to avoid text outline clipping

### DIFF
--- a/pages/404.js
+++ b/pages/404.js
@@ -27,6 +27,7 @@ const pageNotFound = () => (
         font-size: 128px;
         margin: 0;
         line-height: 1.25;
+        letter-spacing: .05em;
       }
       @media (min-width: 32em) {
         h1 {


### PR DESCRIPTION
Before: 
![Before](https://user-images.githubusercontent.com/59726149/166158821-69a5c644-4a8b-4d96-9c49-8c0d6583020f.png)

After:
![After](https://user-images.githubusercontent.com/59726149/166158829-492ede49-9323-4e57-8a66-3ec9a52a8de2.png)

The letter spacing is small enough as to not affect legibility.