### PR TITLE
Let there be streaks page

### DIFF
--- a/components/mention.js
+++ b/components/mention.js
@@ -14,8 +14,8 @@ export const StaticMention = memo(
           width={size}
           height={size}
           className="mention-avatar"
-          style={{ marginRight: '4px' }}
         />
+        {" "}
         @{user.username}
         {children}
       </a>

--- a/components/mention.js
+++ b/components/mention.js
@@ -14,6 +14,7 @@ export const StaticMention = memo(
           width={size}
           height={size}
           className="mention-avatar"
+          style={{ marginRight: '4px' }}
         />
         @{user.username}
         {children}

--- a/pages/api/streaks.js
+++ b/pages/api/streaks.js
@@ -9,6 +9,7 @@ export const getUserStreaks = () =>
     },
     select: {
       username: true,
+      slackID: true,
       avatar: true,
       streakCount: true,
       maxStreaks: true

--- a/pages/api/streaks.js
+++ b/pages/api/streaks.js
@@ -1,0 +1,19 @@
+import prisma from '../../lib/prisma'
+
+export const getUserStreaks = () =>
+  prisma.accounts.findMany({
+    where: {
+      fullSlackMember: true,
+      maxStreaks: {
+        gt: 0
+      }
+    },
+    select: {
+      username: true,
+      avatar: true,
+      streakCount: true,
+      maxStreaks: true
+    }
+  })
+
+export default async (req, res) => getUserStreaks().then(u => res.json(u || []))

--- a/pages/api/streaks.js
+++ b/pages/api/streaks.js
@@ -3,7 +3,6 @@ import prisma from '../../lib/prisma'
 export const getUserStreaks = () =>
   prisma.accounts.findMany({
     where: {
-      fullSlackMember: true,
       maxStreaks: {
         gt: 0
       }

--- a/pages/streaks.js
+++ b/pages/streaks.js
@@ -15,7 +15,12 @@ const StreaksPage = ({ users }) => {
       />
       <style jsx global>{`
         .container {
-          max-width: 500px !important;
+          display: grid;
+          grid-template-columns: 1fr 1fr;
+          place-content: center;
+          place-items: center;
+          place-self: center;
+          max-width: 1000px !important;
           font-size: 20px !important;
           line-height: 1.625;
         }
@@ -35,19 +40,40 @@ const StreaksPage = ({ users }) => {
           justify-content: space-between;
           align-items: center;
           margin-bottom: 0.5em;
+          width: 350px;
+        }
+
+        @media (max-width: 800px) {
+          .container {
+            grid-template-columns: 1fr;
+          }
         }
       `}</style>
 
       <h1>Who's got the highest streak?</h1>
       <main className="container">
-        {orderBy(users, 'maxStreaks', 'desc')
-          .slice(0, 40)
-          .map(u => (
-            <div key={u.id} className="item">
-              <Mention username={u.username} />
-              <p>{u.maxStreaks} 🔥</p>
-            </div>
-          ))}
+        <div>
+          <h2>Current</h2>
+          {orderBy(users, 'streakCount', 'desc')
+            .slice(0, 15)
+            .map(u => (
+              <div key={u.id} className="item">
+                <Mention username={u.username} />
+                <p>{u.streakCount}&nbsp;🔥</p>
+              </div>
+            ))}
+        </div>
+        <div>
+          <h2>All time</h2>
+          {orderBy(users, 'maxStreaks', 'desc')
+            .slice(0, 15)
+            .map(u => (
+              <div key={u.id} className="item">
+                <Mention username={u.username} />
+                <p>{u.maxStreaks}&nbsp;🔥</p>
+              </div>
+            ))}
+        </div>
       </main>
     </>
   )

--- a/pages/streaks.js
+++ b/pages/streaks.js
@@ -55,6 +55,7 @@ const StreaksPage = ({ users }) => {
         <div>
           <h2>Current</h2>
           {orderBy(users, 'streakCount', 'desc')
+            .filter(u => u.slackID !== 'U035D3VA7R7')
             .slice(0, 15)
             .map(u => (
               <div key={u.id} className="item">

--- a/pages/streaks.js
+++ b/pages/streaks.js
@@ -1,0 +1,67 @@
+import Head from 'next/head'
+import Meta from '@hackclub/meta'
+import Mention from '../components/mention'
+import { orderBy } from 'lodash'
+
+const StreaksPage = ({ users }) => {
+  return (
+    <>
+      <Meta
+        as={Head}
+        name="Hack Club's Scrapbook"
+        title="About"
+        description="A daily streak system & portfolio for your projects. Join the Hack Club community & get yours started."
+        image="https://cloud-53i932gta-hack-club-bot.vercel.app/0scrapbook.jpg"
+      />
+      <style jsx global>{`
+        .container {
+          max-width: 500px !important;
+          font-size: 20px !important;
+          line-height: 1.625;
+        }
+
+        h1 {
+          font-size: 3rem;
+          line-height: 1.25;
+          text-align: center;
+          margin-top: 0;
+          margin-bottom: 0.5em;
+          font-style: italic;
+        }
+
+        .item {
+          display: flex;
+          flex-direction: row;
+          justify-content: space-between;
+          align-items: center;
+          margin-bottom: 0.5em;
+        }
+      `}</style>
+
+      <h1>Who's got the highest streak?</h1>
+      <main className="container">
+        {orderBy(users, 'maxStreaks', 'desc')
+          .slice(0, 40)
+          .map(u => (
+            <div key={u.id} className="item">
+              <Mention username={u.username} />
+              <p>{u.maxStreaks} 🔥</p>
+            </div>
+          ))}
+      </main>
+    </>
+  )
+}
+
+export default StreaksPage
+
+export const getStaticProps = async () => {
+  const streaks = require('./api/streaks')
+  const users = await streaks.getUserStreaks()
+  return {
+    props: {
+      users
+    },
+    revalidate: 10
+  }
+}

--- a/pages/streaks.js
+++ b/pages/streaks.js
@@ -8,8 +8,8 @@ const StreaksPage = ({ users }) => {
     <>
       <Meta
         as={Head}
-        name="Hack Club's Scrapbook"
-        title="About"
+        name="Hack Club Scrapbook"
+        title="Streaks"
         description="A daily streak system & portfolio for your projects. Join the Hack Club community & get yours started."
         image="https://cloud-53i932gta-hack-club-bot.vercel.app/0scrapbook.jpg"
       />

--- a/public/themes/default.css
+++ b/public/themes/default.css
@@ -427,3 +427,6 @@ a.post-attachment:first-child:last-child {
   font-size: 14px;
   font-family: var(--fonts-mono);
 }
+.mention-avatar {
+  margin-right: 4px;
+}


### PR DESCRIPTION
The summer streaks leaderboard (streaks.hackclub.com) uses the old Airtable base, so it doesn't reflect posts made after the Airtable -> Prisma/Postgres migration.

This PR adds a /api/streaks endpoint and new /streaks page to view the streaks leaderboard. The page looks a bit boring at the moment though; open to any suggestions/ideas that might spice up the page.

![Screen Shot 2022-05-01 at 15 51 29](https://user-images.githubusercontent.com/72365100/166167795-e4bf46b4-1379-4bd5-96bb-c6c1d82662af.png)

