### PR TITLE
Remove api routes list from the dropdown to fix formatting

### DIFF
--- a/pages/about.mdx
+++ b/pages/about.mdx
@@ -153,17 +153,12 @@ brew install --cask scrapple
 
 This site exposes a public JSON API powered by [Next.js API routes](https://nextjs.org/docs/api-routes/introduction) that formats data in a useful way. The live site runs entirely on this API.
 
-<details>
-  <summary>End points</summary>
-  
 - [`/api/posts`](https://scrapbook.hackclub.com/api/posts) – Get all posts (used on the homepage)
 - [`/api/users`](https://scrapbook.hackclub.com/api/users) – Get all users
 - [`/api/users/:username`](https://scrapbook.hackclub.com/api/users/zrl) – Get a specific user’s profile + posts
 - [`/api/users/:username/mentions`](https://scrapbook.hackclub.com/api/users/sampoder/mentions) – Get a specific user’s mentions
 - [`/api/r/:emoji`](https://scrapbook.hackclub.com/api/r/hardware) – Get all posts tagged with a specific emoji
 - [`/:username.png`](https://scrapbook.hackclub.com/sampoder.png) – Get a user's avatar as an image URL
-
-</details>
 
 ## Contributing
 


### PR DESCRIPTION
Fixes #363 

The site looks good even if the dropdown isn't there + the dropdown is weirdly formatting the lists for some reason.