### PR TITLE
decode text responses as arrayBuffer to prevent overriding specific text content-types

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -70,7 +70,7 @@ export async function middleware(req) {
     if (contentType === "application/json") {
       data = await response.json();
     } else {
-      data = await response.text();
+      data = await response.arrayBuffer();
     }
 
     // attempt to send metric counter
@@ -87,7 +87,7 @@ export async function middleware(req) {
       sendTimerMetric(HOST_NAME, _metricName, time), // send timing metric
     ])
 
-    return contentType === "application/json" ? NextResponse.json(data) : new Response(data);
+    return contentType === "application/json" ? NextResponse.json(data) : new NextResponse(data, { headers: { ...response.headers } });
   } catch (err) {
     return NextResponse.json({ msg: "Failed", reason: err });
   }

--- a/next.config.js
+++ b/next.config.js
@@ -72,6 +72,15 @@ module.exports = withMDX({
         ]
       },
       {
+        source: "/api/css",
+        headers: [
+          {
+            key: "Content-Type",
+            value: "text/css;charset=UTF-8"
+          }
+        ]
+      },
+      {
         source: '/attachments/(.+)',
         headers: [
           { key: 'Access-Control-Allow-Origin', value: '*' },

--- a/pages/[username]/index.js
+++ b/pages/[username]/index.js
@@ -52,12 +52,14 @@ const Profile = ({
           : ''
       }`}
     />
-    {profile.cssURL && (
-      <link
-        rel="stylesheet"
-        href={HOST + `/api/css?url=${profile.cssURL}`}
-      />
-    )}
+    <Head>
+      {profile.cssURL && (
+        <link
+          rel="stylesheet"
+          href={HOST + `/api/css?url=${profile.cssURL}`}
+        />
+      )}
+    </Head>
    {children}
     <header className="header">
       <div className="header-col-1">

--- a/pages/[username]/index.js
+++ b/pages/[username]/index.js
@@ -52,14 +52,12 @@ const Profile = ({
           : ''
       }`}
     />
-    <Head>
-      {profile.cssURL && (
-        <link
-          rel="stylesheet"
-          href={HOST + `/api/css?url=${profile.cssURL}`}
-        />
-      )}
-    </Head>
+    {profile.cssURL && (
+      <link
+        rel="stylesheet"
+        href={HOST + `/api/css?url=${profile.cssURL}`}
+      />
+    )}  
    {children}
     <header className="header">
       <div className="header-col-1">

--- a/pages/[username]/index.js
+++ b/pages/[username]/index.js
@@ -55,11 +55,10 @@ const Profile = ({
     {profile.cssURL && (
       <link
         rel="stylesheet"
-        type="text/css"
         href={HOST + `/api/css?url=${profile.cssURL}`}
       />
     )}
-    {children}
+   {children}
     <header className="header">
       <div className="header-col-1">
         {profile.avatar && (

--- a/pages/api/css.js
+++ b/pages/api/css.js
@@ -1,5 +1,5 @@
 export default async (req, res) => {
-  const { url } = req.query
+  const { url } = req.query;
   if (!url)
     return res
       .status(400)
@@ -9,6 +9,6 @@ export default async (req, res) => {
     return res
       .status(500)
       .json({ status: 500, error: 'Could not download CSS' })
-  res.setHeader('Content-Type', 'text/css')
-  res.send(css)
-}
+
+    res.send(css)
+  }


### PR DESCRIPTION
this indirectly solves the issue where the text/css will be initially set for the /api/css but then change to text/plain in subsequent requests

addresses #811 