### PR TITLE
fix error where app crashes when loading non-existent username

### DIFF
--- a/pages/[username]/index.js
+++ b/pages/[username]/index.js
@@ -15,7 +15,7 @@ import Post from '../../components/post'
 import AudioPlayer from '../../components/audio-player'
 import ExamplePosts from '../../components/example-posts'
 import FourOhFour from '../404'
-// import { exclude } from "../api/posts";
+import { exclude } from "../api/posts";
 
 const HOST =
   process.env.NODE_ENV === 'development' ? '' : 'https://scrapbook.hackclub.com'
@@ -298,9 +298,7 @@ export const getStaticProps = async ({ params }) => {
   const { getProfile, getPosts } = require('../api/users/[username]/index')
   if (params.username?.length < 2)
     return console.error('No username') || { props: {} }
-  const { exclude } = require("../api/posts");
   const profile = exclude(await getProfile(params.username), ['slackID', 'email', 'emailVerified'])
-  // const profile = await getProfile(params.username);
   if (!profile || !profile?.username)
     return console.error('No profile') || { props: {} }
   try {

--- a/pages/[username]/index.js
+++ b/pages/[username]/index.js
@@ -15,7 +15,7 @@ import Post from '../../components/post'
 import AudioPlayer from '../../components/audio-player'
 import ExamplePosts from '../../components/example-posts'
 import FourOhFour from '../404'
-import { exclude } from "../api/posts";
+// import { exclude } from "../api/posts";
 
 const HOST =
   process.env.NODE_ENV === 'development' ? '' : 'https://scrapbook.hackclub.com'
@@ -283,13 +283,13 @@ const UserPage = props => {
 export default UserPage
 
 export const getStaticPaths = async () => {
-  const { map } = require('lodash')
   const { getUsernames } = require('../api/usernames')
   let usernames = await getUsernames({
     where: { fullSlackMember: true },
     orderBy: { streakCount: 'desc' },
     take: 75
   })
+  console.log("got usernames", usernames.length);
   const paths = usernames.map(username => ({ params: { username } }))
   return { paths, fallback: true }
 }
@@ -298,7 +298,9 @@ export const getStaticProps = async ({ params }) => {
   const { getProfile, getPosts } = require('../api/users/[username]/index')
   if (params.username?.length < 2)
     return console.error('No username') || { props: {} }
+  const { exclude } = require("../api/posts");
   const profile = exclude(await getProfile(params.username), ['slackID', 'email', 'emailVerified'])
+  // const profile = await getProfile(params.username);
   if (!profile || !profile?.username)
     return console.error('No profile') || { props: {} }
   try {
@@ -337,4 +339,5 @@ export const getStaticProps = async ({ params }) => {
     console.error(error)
     return { props: { profile }, revalidate: 1 }
   }
+
 }

--- a/pages/[username]/index.js
+++ b/pages/[username]/index.js
@@ -289,7 +289,6 @@ export const getStaticPaths = async () => {
     orderBy: { streakCount: 'desc' },
     take: 75
   })
-  console.log("got usernames", usernames.length);
   const paths = usernames.map(username => ({ params: { username } }))
   return { paths, fallback: true }
 }

--- a/pages/api/posts.js
+++ b/pages/api/posts.js
@@ -5,6 +5,7 @@ import prisma from '../../lib/prisma'
 import { emailToPfp } from '../../lib/email'
 
 export function exclude(object, keys) {
+  if (!object) return {}
   return Object.fromEntries(Object.entries(object).filter(([key]) => !keys.includes(key)));
 }
 


### PR DESCRIPTION
The `exclude` function used to exclude fields would break when passed `null` as object value. Made it return empty object when falsy value (such as null and undefined) is passed