### PR TITLE
use the hosted app url as base url for requests

### DIFF
--- a/apps/web/middleware.js
+++ b/apps/web/middleware.js
@@ -27,7 +27,7 @@ async function sendTimerMetric(hostName, metricKey, time) {
 export async function middleware(req) {
   const url = new URL(decodeURIComponent(req.url));
 
-  const HOST_NAME = "http://" + url.host;
+  const HOST_NAME = process.env.APP_URL;
 
   let _metricName = url.pathname.slice(1).split("/").join("_");
 
@@ -42,7 +42,7 @@ export async function middleware(req) {
   const startTime = new Date().getTime();
   const hasFormData = req.headers.get("Content-Type")?.includes("multipart/form-data");
 
-  const response = await fetch(req.url, {
+  const response = await fetch(HOST_NAME + url.pathname, {
     method: req.method,
     headers: req.headers,
     body: hasFormData ? await req.formData() : req.body


### PR DESCRIPTION
Previously the middleware will forward requests to using https on localhost which doesn't work as there's no SSL certificate. This change ensures that requests are forwarded through the hosted app url (in this case, `https://scrapbook.hackclub.com`)