### PR TITLE
don't try to get user timezone information if the `fields` property on their profile is null

### DIFF
--- a/apps/slack-bot/src/events/userChanged.js
+++ b/apps/slack-bot/src/events/userChanged.js
@@ -34,7 +34,7 @@ export default async ({ event }) => {
 
     // if a user does not have the fields property on them
     // then they probably don't have timezone information available as well
-    if (!info.user.profile.fields) return;
+    if (info.user.profile.fields === null) return;
 
     // return if we got an unsuccessful response from Slack
     if (!info.ok) return;

--- a/apps/slack-bot/src/events/userChanged.js
+++ b/apps/slack-bot/src/events/userChanged.js
@@ -8,7 +8,7 @@ export default async ({ event }) => {
   try {
     const { user } = event;
     const statusEmoji = user.profile.status_emoji;
-    if (statusEmoji?.startsWith("som-") && 
+    if (statusEmoji?.startsWith("som-") &&
     // the character that follows "som-" MUST be a numbe
     !Number.isNaN(parseInt(statusEmoji?.slice("som-".length)[0]))
   ) {
@@ -31,8 +31,13 @@ export default async ({ event }) => {
     });
     // return if there is no user with this slackID
     if (!user.profile.fields) return;
+
+    // if a user does not have the fields property on them
+    // then they probably don't have timezone information available as well
+    if (!info.user.profile.fields) return;
+
     // return if we got an unsuccessful response from Slack
-    if (!info.ok) return; 
+    if (!info.ok) return;
     await prisma.accounts.update({
       where: { slackID: user.id },
       data: {


### PR DESCRIPTION
I realised that when a user has the 'fields' property as null on their profile, they don't have their timezone information available